### PR TITLE
Remove Multidex usages

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -18,7 +18,6 @@ object Dependencies {
     const val androidx_work_runtime = "androidx.work:work-runtime:${Versions.work}"
     const val androidx_cardview = "androidx.cardview:cardview:1.0.0"
     const val androidx_exinterface = "androidx.exifinterface:exifinterface:1.3.6"
-    const val androidx_multidex = "androidx.multidex:multidex:2.0.1"
     const val androidx_preference_ktx = "androidx.preference:preference-ktx:1.2.0"
     const val androidx_fragment_ktx = "androidx.fragment:fragment-ktx:${Versions.androidx_fragment}"
     const val android_material = "com.google.android.material:material:1.7.0"
@@ -89,7 +88,6 @@ object Dependencies {
     const val androidx_test_ext_junit = "androidx.test.ext:junit:1.1.5"
     const val okhttp3_mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.okhttp3}"
     const val hamcrest = "org.hamcrest:hamcrest:2.2"
-    const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val robolectric_shadows_multidex = "org.robolectric:shadows-multidex:${Versions.robolectric}"
+    const val robolectric = "org.robolectric:robolectric:4.9"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 }

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -11,7 +11,6 @@ object Versions {
     const val glide = "4.15.1"
     const val mockito = "5.2.0"
     const val okhttp3 = "4.10.0"
-    const val robolectric = "4.9"
     const val work = "2.8.0"
     const val lifecycle = "2.6.0"
     const val camerax = "1.2.1"

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -78,7 +78,6 @@ android {
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')
-        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
         archivesBaseName = 'collect'
     }
@@ -280,7 +279,6 @@ dependencies {
     implementation Dependencies.androidx_work_runtime
 
     implementation Dependencies.androidx_cardview
-    implementation Dependencies.androidx_multidex
     implementation Dependencies.androidx_preference_ktx
     implementation Dependencies.androidx_fragment_ktx
 
@@ -381,7 +379,6 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_ext_junit
     testImplementation Dependencies.androidx_arch_core_testing
-    testImplementation Dependencies.robolectric_shadows_multidex
     testImplementation Dependencies.okhttp3_mockwebserver
     testImplementation Dependencies.squareup_okhttp_tls
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -22,7 +22,6 @@ import android.content.res.Configuration;
 import android.os.StrictMode;
 
 import androidx.annotation.NonNull;
-import androidx.multidex.MultiDex;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.BuildConfig;
@@ -120,16 +119,6 @@ public class Collect extends Application implements
 
     public void setExternalDataManager(ExternalDataManager externalDataManager) {
         this.externalDataManager = externalDataManager;
-    }
-
-    /*
-        Adds support for multidex support library. For more info check out the link below,
-        https://developer.android.com/studio/build/multidex.html
-    */
-    @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        MultiDex.install(this);
     }
 
     @Override

--- a/wireless-geo/build.gradle
+++ b/wireless-geo/build.gradle
@@ -22,7 +22,6 @@ android {
         targetSdkVersion Versions.android_target_sdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-        multiDexEnabled true
     }
 
     buildTypes {


### PR DESCRIPTION
Since the min SDK is 26, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l